### PR TITLE
[Fix] 타일 전환 시 인터렉트 UI 딜레이 추가

### DIFF
--- a/Assets/KST/Scripts/TileSys/FarmTile.cs
+++ b/Assets/KST/Scripts/TileSys/FarmTile.cs
@@ -11,6 +11,8 @@ public class FarmTile : MonoBehaviour, IToolInteractable
     [Header("UI")]
     //상호작용 UI
     public GameObject InteractUiText;
+    public float m_interactDelay = 0.5f;
+    public float m_awakeTime;
     private bool m_isInteract;
     //농사창 UI
     // public GameObject FarmUIObj;
@@ -24,6 +26,8 @@ public class FarmTile : MonoBehaviour, IToolInteractable
     //     m_isPlanted = true;
 
     // }
+    void Awake() => m_awakeTime = Time.time;
+        
     void OnEnable()
     {
         FarmUI.Instance.OnIsUIOpen +=SetInteraction;
@@ -82,6 +86,7 @@ public class FarmTile : MonoBehaviour, IToolInteractable
     {
         if (other.CompareTag("Player"))
         {
+            if (Time.time - m_awakeTime < m_interactDelay) return;
             //플레이어가 타일위에 있는지
             m_isPlayerOnFarmTile = true;
             // //플레이어가 상호작용을 통해 UI를 오픈했는지.


### PR DESCRIPTION
타일이 개척지 -> 경작지로 변환 시 FarmTile 컴포넌트 부착 타이밍 과 인터렉트 상호작용 키 입력 시점이 일치하여 바로 농사 UI가 켜지는 문제를 다음과 같이 인터렉트 UI를  0.5초 딜레이를 줘서 해결